### PR TITLE
Stabilize frontend tests and add ESLint TS deps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,8 @@
   "devDependencies": {
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "@typescript-eslint/parser": "^7.17.0",
     "@vitejs/plugin-react": "^4.2.1",
     "@vitest/ui": "^1.6.0",
     "@testing-library/react": "^14.3.1",

--- a/frontend/src/__tests__/basic.test.js
+++ b/frontend/src/__tests__/basic.test.js
@@ -8,15 +8,15 @@ describe('Basic System Tests', () => {
 
   it('should have valid JavaScript syntax', async () => {
     // Import main modules to ensure they compile
-    const { executeCommand } = await import('../../utils/commands')
-    const { getUserStatus } = await import('../../utils/userState')
+    const { executeCommand } = await import('../utils/commands')
+    const { getUserStatus } = await import('../utils/userState')
     
     expect(typeof executeCommand).toBe('function')
     expect(typeof getUserStatus).toBe('function')
   })
 
   it('should handle basic command structure', async () => {
-    const { getCommandSuggestions } = await import('../../utils/commands')
+    const { getCommandSuggestions } = await import('../utils/commands')
     
     // Test that suggestions work
     const suggestions = getCommandSuggestions('he')

--- a/frontend/src/__tests__/utils/logger.test.js
+++ b/frontend/src/__tests__/utils/logger.test.js
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { logger, performanceLogger, walletLogger, rpcLogger, Logger } from '../../utils/logger'
+import { logger, performanceLogger, walletLogger, rpcLogger, Logger, LogLevel } from '../../utils/logger'
 
 describe('Logging System', () => {
   beforeEach(() => {
     // Clear console mocks
     vi.clearAllMocks()
-    
+
     // Mock console methods
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
     vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Reset logger state
+    logger.level = LogLevel.DEBUG
+    logger.enableStorage = true
+    logger.clearLogs()
   })
 
   describe('Logger', () => {
@@ -209,15 +214,16 @@ describe('Logging System', () => {
 
     it('should capture unhandled promise rejections', () => {
       vi.spyOn(logger, 'error')
-      
+
       // Simulate an unhandled promise rejection
-      const rejectionEvent = new PromiseRejectionEvent('unhandledrejection', {
-        promise: Promise.reject(new Error('Test rejection')),
+      const rejectionEvent = new Event('unhandledrejection')
+      Object.assign(rejectionEvent, {
+        promise: Promise.resolve(),
         reason: new Error('Test rejection')
       })
-      
+
       window.dispatchEvent(rejectionEvent)
-      
+
       expect(logger.error).toHaveBeenCalledWith(
         'Unhandled promise rejection',
         expect.objectContaining({

--- a/frontend/src/utils/commands/staking.js
+++ b/frontend/src/utils/commands/staking.js
@@ -1,4 +1,5 @@
 import { mockWalletState } from '../userState';
+import { validateTransactionAmount } from '../security';
 
 export const stakingCommands = {
   status: () => {


### PR DESCRIPTION
## Summary
- Reset logger state between tests and simulate unhandled rejections without PromiseRejectionEvent
- Unlock and mock security utilities in command tests, fix relative imports
- Add @typescript-eslint parser and plugin for linting

## Testing
- `npm run test:run --prefix frontend`
- `npm run lint --prefix frontend` *(fails: ESLint couldn't find config "@typescript-eslint/recommended"; npm install blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_689748d262888326a9c783fabe4aa37c